### PR TITLE
add: Metadata at Scale blog by Arnav Borkar (2025-10-16)

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -61,6 +61,16 @@
       "tags": ["Apache Iceberg", "Apache Polaris"]
     },
     {
+      "title": "Metadata at Scale: Tackling Apache Iceberg Tables with Tens of Millions of Files",
+      "date": "2025-10-16",
+      "url": "https://www.e6data.com/blog/apache-iceberg-million-files-metadata",
+      "company": "e6data",
+      "author": "Arnav Borkar",
+      "author_url": "https://www.linkedin.com/in/arnavborkar/",
+      "project_slugs": ["iceberg", "spark", "trino"],
+      "tags": ["Apache Iceberg", "Apache Spark", "Trino"]
+    },
+    {
       "title": "Try Apache Polaris (incubating) on Your Laptop with Minio",
       "date": "2025-10-14",
       "url": "https://www.dremio.com/blog/try-apache-polaris-incubating-on-your-laptop-with-minio/",


### PR DESCRIPTION
## Blog Details

**Title:** Metadata at Scale: Tackling Apache Iceberg Tables with Tens of Millions of Files  
**Date:** 2025-10-16  
**URL:** https://www.e6data.com/blog/apache-iceberg-million-files-metadata  
**Company:** e6data  
**Author:** Arnav Borkar  

## Summary
This blog explores how to handle Apache Iceberg tables with tens of millions of files (45M+ files, ~5TB metadata). It covers:
- Streaming metadata reads to prevent OOM crashes
- Layered pruning at partition and file levels
- Treating metadata as first-class data for query optimization

**Tags:** Apache Iceberg, Apache Spark, Trino